### PR TITLE
Add support for GET parameters

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -1,6 +1,7 @@
 const crypto = require("crypto");
 const OAuth = require("oauth-1.0a");
 const Fetch = require("cross-fetch");
+const querystring = require("querystring");
 
 const getUrl = subdomain => `https://${subdomain}.twitter.com/1.1`;
 const createOauthClient = ({ key, secret }) => {
@@ -52,9 +53,11 @@ class Twitter {
 
   async get(resource) {
     const requestData = {
-      url: `${this.url}/${resource}.json`,
+      url: `${this.url}/${resource}.json?${querystring.stringify(parameters)}`,
       method: "GET"
     };
+    if (parameters)
+      requestData.url += "?" + querystring.stringify(parameters);
 
     let headers = {};
     if (this.authType === "User") {

--- a/twitter.js
+++ b/twitter.js
@@ -51,9 +51,9 @@ class Twitter {
     this.config = config;
   }
 
-  async get(resource) {
+  async get(resource, parameters) {
     const requestData = {
-      url: `${this.url}/${resource}.json?${querystring.stringify(parameters)}`,
+      url: `${this.url}/${resource}.json`,
       method: "GET"
     };
     if (parameters)


### PR DESCRIPTION
From what I've seen so far, no Twitter APIs take nested objects as parameters, so querystring should suffice. Otherwise, we can use the [qs](https://www.npmjs.com/package/qs) module.